### PR TITLE
Made mathicsscript XDG compatible

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,1 +1,0 @@
-/home/pablo/Documents/mathicsscript/mathicsscript/__main__.py

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,1 @@
+/home/pablo/Documents/mathicsscript/mathicsscript/__main__.py

--- a/mathicsscript/termshell.py
+++ b/mathicsscript/termshell.py
@@ -58,7 +58,7 @@ from readline import (
 # Set up mathicsscript configuration directory
 CONFIGHOME = os.environ.get("XDG_CONFIG_HOME", osp.expanduser("~/.config"))
 CONFIGDIR = os.path.join(CONFIGHOME, "mathicsscript")
-os.makedir(CONFIGDIR, exist_ok=True)
+os.makedirs(CONFIGDIR, exist_ok=True)
 
 try:
     HISTSIZE = int(os.environ.get("MATHICSSCRIPT_HISTSIZE", 50))

--- a/mathicsscript/termshell.py
+++ b/mathicsscript/termshell.py
@@ -55,12 +55,17 @@ from readline import (
     write_history_file,
 )
 
+# Set up mathicsscript configuration directory
+CONFIGHOME = os.environ.get("XDG_CONFIG_HOME", osp.expanduser("~/.config"))
+CONFIGDIR = os.path.join(CONFIGHOME, "mathicsscript")
+os.makedir(CONFIGDIR, exist_ok=True)
+
 try:
     HISTSIZE = int(os.environ.get("MATHICSSCRIPT_HISTSIZE", 50))
 except:
     HISTSIZE = 50
 
-HISTFILE = osp.expanduser("~/.mathicsscript_hist")
+HISTFILE = os.path.join(CONFIGDIR, "history")
 
 RL_COMPLETER_DELIMS_WITH_BRACE = " \t\n_~!@#%^&*()-=+{]}|;:'\",<>/?"
 RL_COMPLETER_DELIMS = " \t\n_~!@#%^&*()-=+[{]}\\|;:'\",<>/?"


### PR DESCRIPTION
Made mathicsscript [XDG](https://wiki.archlinux.org/index.php/XDG_Base_Directory)-compatible.