### PR TITLE
Fix the previous issues with the histfile and XDG

### DIFF
--- a/mathicsscript/termshell.py
+++ b/mathicsscript/termshell.py
@@ -63,13 +63,15 @@ CONFIGDIR = os.path.join(CONFIGHOME, "mathicsscript")
 os.makedirs(CONFIGDIR, exist_ok=True)
 
 try:
-    HISTSIZE = int(os.environ.get("MATHICSSCRIPT_HISTSIZE", 50))
+    HISTSIZE = int(os.environ.get("MATHICSSCRIPT_HISTSIZE"))
 except:
     HISTSIZE = 50
 
-# This doesn't work: investigate
-# HISTFILE = os.path.join(CONFIGDIR, "history")
-HISTFILE = osp.expanduser("~/.mathicsscript_hist")
+HISTFILE = os.path.join(CONFIGDIR, "history")
+
+# Create HISTFILE if it doesn't exist already
+if not os.path.isfile(HISTFILE):
+    pathlib.Path(HISTFILE).touch()
 
 RL_COMPLETER_DELIMS_WITH_BRACE = " \t\n_~!@#%^&*()-=+{]}|;:'\",<>/?"
 RL_COMPLETER_DELIMS = " \t\n_~!@#%^&*()-=+[{]}\\|;:'\",<>/?"


### PR DESCRIPTION
This is a follow up to https://github.com/Mathics3/mathicsscript/pull/5#issuecomment-734895915. I think the issue was that mathicsscript failed to open the histfile when it didn't exist (and subsequently never got around to creating it), so I added a check for this at startup. I've tested things locally and everything is working.