### PR TITLE
Replace named characters with plain text before printing the output

### DIFF
--- a/mathicsscript/__main__.py
+++ b/mathicsscript/__main__.py
@@ -243,7 +243,7 @@ def main(
             )
             shell.terminal_formatter = None
             result = evaluation.parse_evaluate(expr, timeout=settings.TIMEOUT)
-            shell.print_result(result, unicode, output_style="text")
+            shell.print_result(result, "text")
 
             # After the next release, we can remove the hasattr test.
             if hasattr(evaluation, "exc_result"):
@@ -346,7 +346,7 @@ def main(
                 query, timeout=settings.TIMEOUT, format="unformatted"
             )
             if result is not None:
-                shell.print_result(result, unicode, output_style=output_style)
+                shell.print_result(result, output_style)
 
         except ShellEscapeException as e:
             source_code = e.line

--- a/mathicsscript/__main__.py
+++ b/mathicsscript/__main__.py
@@ -243,7 +243,7 @@ def main(
             )
             shell.terminal_formatter = None
             result = evaluation.parse_evaluate(expr, timeout=settings.TIMEOUT)
-            shell.print_result(result, "text")
+            shell.print_result(result, unicode, output_style="text")
 
             # After the next release, we can remove the hasattr test.
             if hasattr(evaluation, "exc_result"):
@@ -346,7 +346,7 @@ def main(
                 query, timeout=settings.TIMEOUT, format="unformatted"
             )
             if result is not None:
-                shell.print_result(result, output_style)
+                shell.print_result(result, unicode, output_style=output_style)
 
         except ShellEscapeException as e:
             source_code = e.line

--- a/mathicsscript/termshell.py
+++ b/mathicsscript/termshell.py
@@ -9,7 +9,11 @@ import pathlib
 import sys
 import re
 from columnize import columnize
-from mathics_scanner import replace_unicode_with_wl, named_characters
+from mathics_scanner import (
+    replace_wl_with_plain_text, 
+    replace_unicode_with_wl, 
+    named_characters
+)
 from mathics.core.expression import Expression, String, Symbol
 from mathics.core.expression import strip_context, from_python
 from mathics.core.rules import Rule
@@ -255,7 +259,7 @@ class TerminalShell(LineFeeder):
             raise ShellEscapeException(line)
         return replace_unicode_with_wl(line)
 
-    def print_result(self, result, output_style=""):
+    def print_result(self, result, use_unicode, output_style=""):
         if result is None:
             # FIXME decide what to do here
             return
@@ -269,7 +273,8 @@ class TerminalShell(LineFeeder):
                 print(sys.exc_info()[1])
                 return
 
-            out_str = str(result.result)
+            out_str = replace_wl_with_plain_text(str(result.result), 
+                                                 use_unicode=use_unicode)
             if eval_type == "System`Graph":
                 out_str = "-Graph-"
             elif self.terminal_formatter:  # pygmentize


### PR DESCRIPTION
We should replace named-characters in the output strings before they get printed. This was implemented in https://github.com/Mathics3/mathicsscript/pull/13 but it wasn't copied to https://github.com/Mathics3/mathicsscript/pull/17.