### PR TITLE
Asymptote

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -21,6 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        brew install mathicsscript
         python -m pip install --upgrade pip
         python -m pip install -e .
         # Can remove when next Mathics is released

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
+        sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev asymptote
         python -m pip install --upgrade pip
         python -m pip install -e .
         # Can remove when next Mathics is released

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,9 @@ repos:
     hooks:
     - id: debug-statements
     - id: end-of-file-fixer
+    - id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.6b0
     hooks:
     - id: black
       language_version: python3

--- a/mathicsscript/asymptote.py
+++ b/mathicsscript/asymptote.py
@@ -6,9 +6,10 @@ from subprocess import Popen, PIPE
 
 
 class asy:
-    def __init__(self):
+    def __init__(self, show_help=True):
         self.session = Popen(["asy", "-quiet", "-inpipe=0", "-outpipe=2"], stdin=PIPE)
-        self.help()
+        if show_help:
+            self.help()
 
     def send(self, cmd):
         self.session.stdin.write(bytes(cmd + "\n", "utf-8"))

--- a/mathicsscript/asymptote.py
+++ b/mathicsscript/asymptote.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Python module to feed Asymptote with commands
+# (modified from gnuplot.py)
+from subprocess import Popen, PIPE
+
+
+class asy:
+    def __init__(self):
+        self.session = Popen(["asy", "-quiet", "-inpipe=0", "-outpipe=2"], stdin=PIPE)
+        self.help()
+
+    def send(self, cmd):
+        self.session.stdin.write(bytes(cmd + "\n", "utf-8"))
+        self.session.stdin.flush()
+
+    def size(self, size):
+        self.send("size(%d);" % size)
+
+    def draw(self, str):
+        self.send("draw(%s);" % str)
+
+    def fill(self, str):
+        self.send("fill(%s);" % str)
+
+    def clip(self, str):
+        self.send("clip(%s);" % str)
+
+    def label(self, str):
+        self.send("label(%s);" % str)
+
+    def shipout(self, str):
+        self.send('shipout("%s");' % str)
+
+    def erase(self):
+        self.send("erase();")
+
+    def help(self):
+        print("Asymptote session is open.  Available methods are:")
+        print(
+            "    help(), size(int), draw(str), fill(str), clip(str), label(str), shipout(str), send(str), erase()"
+        )
+
+    def __del__(self):
+        print("closing Asymptote session...")
+        self.send("quit")
+        self.session.stdin.close()
+        self.session.wait()
+
+
+if __name__ == "__main__":
+    g = asy()
+    g.size(200)
+    g.draw("unitcircle")
+    g.send("draw(unitsquare)")
+    g.fill("unitsquare,blue")
+    g.clip("unitcircle")
+    g.label('"$O$",(0,0),SW')
+    input("press ENTER to continue")
+    g.erase()
+    del g

--- a/mathicsscript/autoload/settings.m
+++ b/mathicsscript/autoload/settings.m
@@ -24,6 +24,9 @@ Settings`$PygmentsShowTokens = False
 Settings`$UseUnicode::usage = "This Boolean variable sets whether Unicode is used in terminal input and output."
 Settings`$UseUnicode = True
 
+Settings`$UseAsymptote::usage = "This Boolean variable sets whether 3D Graphics should render using Asymptote."
+Settings`$UseAsymptote = True
+
 Settings`MathicsScriptVersion::usage = "This string is the version of MathicsScript we are running."
 
 System`$Notebooks::usage = "Set True if the Mathics is being used with a notebook-based front end."

--- a/mathicsscript/format.py
+++ b/mathicsscript/format.py
@@ -22,6 +22,9 @@ try:
 except ImportError:
     svg2png = None
 
+from mathicsscript.asymptote import asy
+asymptote_graph=asy(show_help=False)
+asymptote_graph.size(200)
 
 def format_output(obj, expr, format=None):
     def eval_boxes(result, fn, obj, **options):
@@ -73,6 +76,18 @@ def format_output(obj, expr, format=None):
                 temp_png.close()
             except:  # noqa
                 pass
+        return expr_type
+    elif expr_type in ("System`Graphics3D",):
+        form_expr = Expression("TeXForm", expr)
+        result = form_expr.format(obj, "System`OutputForm")
+        # HACK ALERT
+        # Result is Expression[RowBox[List[String ...] so the following extracts
+        # the string part by hacky navigation.
+        asy_str = result.get_leaves()[0].get_leaves()[0].to_python(string_quotes=False)
+        # More hack alert: remove \n\begin{{asy} and \end{asy}
+        asy_lines = asy_str.split("\n")[2:-2]
+        asymptote_graph.erase()
+        asymptote_graph.send("\n".join(asy_lines))
         return expr_type
 
     if format == "text":

--- a/mathicsscript/format.py
+++ b/mathicsscript/format.py
@@ -7,6 +7,7 @@ import networkx as nx
 import random
 from tempfile import NamedTemporaryFile
 
+from mathics.core.expression import String
 try:
     import matplotlib.pyplot as plt
 except ImportError:
@@ -68,10 +69,9 @@ def format_output(obj, expr, format=None):
         if len(leaves) == 1:
             expr = leaves[0]
     elif expr_type in ("System`Graphics", "System`Plot"):
-        form_expr = Expression("StandardForm", expr)
-        result = form_expr.format(obj, "System`StandardForm")
-        if plt and svg2png and hasattr(result, "boxes_to_svg"):
-            svg_str = eval_boxes(result, result.boxes_to_svg, obj)
+        if plt and svg2png:
+            svg_expr = Expression("ExportString", expr, String("SVG"))
+            svg_str = svg_expr.evaluate(obj).to_python(string_quotes=False)
             temp_png = NamedTemporaryFile(
                 mode="w+b", suffix=".png", prefix="mathicsscript-"
             )
@@ -86,16 +86,10 @@ def format_output(obj, expr, format=None):
                 pass
         return expr_type
     elif expr_type in ("System`Graphics3D",) and have_asymptote:
-        form_expr = Expression("TeXForm", expr)
-        result = form_expr.format(obj, "System`OutputForm")
-        # HACK ALERT
-        # Result is Expression[RowBox[List[String ...] so the following extracts
-        # the string part by hacky navigation.
-        asy_str = result.get_leaves()[0].get_leaves()[0].to_python(string_quotes=False)
-        # More hack alert: remove \n\begin{{asy} and \end{asy}
-        asy_lines = asy_str.split("\n")[2:-2]
+        asy_expr = Expression("ExportString", expr, String("asy"))
+        asy_str = asy_expr.evaluate(obj).to_python(string_quotes=False)
         asymptote_graph.erase()
-        asymptote_graph.send("\n".join(asy_lines))
+        asymptote_graph.send(asy_str)
         return expr_type
 
     if format == "text":

--- a/mathicsscript/format.py
+++ b/mathicsscript/format.py
@@ -8,6 +8,7 @@ import random
 from tempfile import NamedTemporaryFile
 
 from mathics.core.expression import String
+
 try:
     import matplotlib.pyplot as plt
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -46,21 +46,19 @@ exec(read("mathicsscript/version.py"))
 
 is_PyPy = platform.python_implementation() == "PyPy"
 
-dev_requires = []
-for line in open("requirements-dev.txt").read().split("\n"):
-    if line and not line.startswith("#"):
-        requires = re.sub(r"([^#]+)(\s*#.*$)?", r"\1", line)
-        dev_requires.append(requires)
-full_requires = []
-for line in open("requirements-full.txt").read().split("\n"):
-    if line and not line.startswith("#"):
-        requires = re.sub(r"([^#]+)(\s*#.*$)?", r"\1", line)
-        full_requires.append(requires)
-
+EXTRAS_REQUIRE = {}
+for kind in ("dev", "full"):
+    extras_require = []
+    requirements_file = f"requirements-{kind}.txt"
+    for line in open(requirements_file).read().split("\n"):
+        if line and not line.startswith("#"):
+            requires = re.sub(r"([^#]+)(\s*#.*$)?", r"\1", line)
+            extras_require.append(requires)
+    EXTRAS_REQUIRE[kind] = extras_require
 
 setup(
     maintainer="Mathics Group",
-    maintainer_email="mathic-devel@googlegroups.com",
+    maintainer_email="mathics-devel@googlegroups.com",
     author_email="rb@dustyfeet.com",
     name="mathicsscript",
     version=__version__,  # noqa
@@ -88,7 +86,7 @@ setup(
         "term-background >= 1.0.1",
     ],
     entry_points={"console_scripts": ["mathicsscript = mathicsscript.__main__:main"]},
-    extras_require={"dev": dev_requires, "full": full_requires},
+    extras_require=EXTRAS_REQUIRE,
     long_description=long_description,
     long_description_content_type="text/x-rst",
     # don't pack Mathics in egg because of media files, etc.


### PR DESCRIPTION
This finally gives us a way to more easily check asymptote formatting. 

As is Mathics custom though, right now the only way you can get at Asymptote is via TeXForm and when you do that we have the unwanted `\begin{asy}` and `\end{asy}` which we have to hackily strip out here. 

So on the Mathics side we'll have to address this like we did for SVG, and JSON. 

If there is one huge misfeature that prevents scaling that we see over and over again is wrapping multiple layers into one huge pile of code (and originally in a single repository). 

So expect in the future changes to Mathics around this.

Also I haven't hooked in the new `Settings`$UseAsymptote` yet.