### PR TITLE
Check if `self` has `session` attribute in `asy.__del__`

### DIFF
--- a/mathicsscript/asymptote.py
+++ b/mathicsscript/asymptote.py
@@ -44,9 +44,13 @@ class asy:
 
     def __del__(self):
         # print("closing Asymptote session...")
-        self.send("quit")
-        self.session.stdin.close()
-        self.session.wait()
+        # Popen in __init__ can fail (e.g. asymptote is not intalled), so self
+        # potentially does not have a sesion attribute and without this check an
+        # AttributeError can get logged
+        if hasattr(self, "session"):
+            self.send("quit")
+            self.session.stdin.close()
+            self.session.wait()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This stops this error from being logged every time `mathicsscript` is invoked if Asymptote is not
installed:

```
Exception ignored in: <function asy.__del__ at 0x11358fe50>
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/mathicsscript/asymptote.py", line 47, in __del__
    self.send("quit")
  File "/usr/local/lib/python3.9/site-packages/mathicsscript/asymptote.py", line 15, in send
    self.session.stdin.write(bytes(cmd + "\n", "utf-8"))
AttributeError: 'asy' object has no attribute 'session'
```