### PR TITLE
Add config.asy and psviewer that removes trash

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,9 +4,11 @@ include ChangeLog
 include COPYING.txt
 include Makefile
 include mathicsscript/autoload/settings.m
+include mathicsscript/config.asy
 include mathicsscript/data/inputrc-no-unicode
 include mathicsscript/data/inputrc-unicode
 include mathicsscript/data/mma-tables.json
+include mathicsscript/fake_psviewer.py
 include mathicsscript/user-settings.m
 recursive-include mathicsscript *.py
 recursive-include test *.py *.m

--- a/mathicsscript/asymptote.py
+++ b/mathicsscript/asymptote.py
@@ -1,13 +1,31 @@
 #!/usr/bin/env python3
+"""Python module to feed Asymptote with commands
+(modified from gnuplot.py)
+"""
 
-# Python module to feed Asymptote with commands
-# (modified from gnuplot.py)
+import os
+import os.path as osp
+
 from subprocess import Popen, PIPE
+
+asy_program = os.environ.get("ASY_PROG", "asy")
+
+
+def get_srcdir():
+    filename = osp.normcase(osp.dirname(osp.abspath(__file__)))
+    return osp.realpath(filename)
+
+
+mydir = get_srcdir()
+asy_config = os.path.join(mydir, "config.asy")
 
 
 class Asy(object):
     def __init__(self, show_help=True):
-        self.session = Popen(["asy", "-quiet", "-inpipe=0", "-outpipe=2"], stdin=PIPE)
+        self.session = Popen(
+            [asy_program, f"-config={asy_config}", "-quiet", "-inpipe=0", "-outpipe=2"],
+            stdin=PIPE,
+        )
         if show_help:
             self.help()
 

--- a/mathicsscript/config.asy
+++ b/mathicsscript/config.asy
@@ -1,0 +1,5 @@
+// This is an Asymptote configuration file for mathicsscript.
+// We set up a fake_previewer which will remove out.eps
+// that Asymptote wants to create
+import settings;
+psviewer="fake_psviewer.py";

--- a/mathicsscript/fake_psviewer.py
+++ b/mathicsscript/fake_psviewer.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env Python
+# -*- coding: utf-8 -*-
+"""
+This is a replacement for a PostScript previewer like gv
+which does nothing, but remove any file argument it is
+given.
+
+Asymptote run via mathicsscript will create an embeded postscript file out.eps
+which should be removed.
+"""
+import os
+import sys
+
+
+def main():
+    if len(sys.argv) > 1:
+        eps_file = sys.argv[1]
+        if os.path.exists(eps_file):
+            os.remove(eps_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -70,10 +70,11 @@ setup(
             "mathicsscript/data/inputrc-unicode",
             "mathicsscript/user-settings.m",
             "mathicsscript/autoload/settings.m",
+            "mathicsscript/config.asy",
         ]
     },
     install_requires=[
-        "Mathics_Scanner>=1.2.2",
+        "Mathics_Scanner>=1.2.4",
         "Mathics3 >= 4.0.0,<4.1.0",
         "click",
         "colorama",
@@ -85,7 +86,12 @@ setup(
         "mathics_pygments>=1.0.2",
         "term-background >= 1.0.1",
     ],
-    entry_points={"console_scripts": ["mathicsscript = mathicsscript.__main__:main"]},
+    entry_points={
+        "console_scripts": [
+            "mathicsscript = mathicsscript.__main__:main",
+            "fake_psviewer.py = mathicsscript.fake_psviewer:main",
+        ]
+    },
     extras_require=EXTRAS_REQUIRE,
     long_description=long_description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
To remove the useless eps.out file that is created by Asymptote
and to prevent an annoying gv popup, we create our own
config.asy, and arrange to have it run a program to remove
the out.eps (the programs file argument).