### PR TITLE
Allow user inputrc for prompt_toolkit and...

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 --------
 
 * Add $GroupAutoComplete setting (default True) to disable completing closer group symbol. Feature provided by DUO Labs.
+* For prompt-toolkit users, we allow a user input binding file in CONFIGDIR/inputrc (e.g. ~/.config/mathicsscript/inputrc).
+  You can set the location this file via environment variable MATHICS_INPUTRC
+
 
 4.0.0
 -----

--- a/mathicsscript/termshell.py
+++ b/mathicsscript/termshell.py
@@ -53,6 +53,7 @@ except:
     HISTSIZE = 50
 
 HISTFILE = os.environ.get("MATHICS_HISTFILE", osp.join(CONFIGDIR, "history"))
+USER_INPUTRC = os.environ.get("MATHICS_INPUTRC", osp.join(CONFIGDIR, "inputrc"))
 
 # Create HISTFILE if it doesn't exist already
 if not osp.isfile(HISTFILE):

--- a/mathicsscript/termshell_gnu.py
+++ b/mathicsscript/termshell_gnu.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
-#   Copyright (C) 2020-2021 Rocky Bernstein <rb@dustyfeet.com>
+#   Copyright (C) 2020-2022 Rocky Bernstein <rb@dustyfeet.com>
 
 import atexit
 import os.path as osp
 import pathlib
 import sys
 import re
+from mathicsscript.bindkeys import read_inputrc
 from mathics_scanner import named_characters
 from mathicsscript.termshell import CONFIGDIR, HISTSIZE, TerminalShellCommon
 from mathics.core.symbols import strip_context
@@ -68,13 +69,7 @@ class TerminalShellGNUReadline(TerminalShellCommon):
 
                 # GNU Readling inputrc $include's paths are relative to itself,
                 # so chdir to its directory before reading the file.
-                parent_dir = pathlib.Path(__file__).parent.absolute()
-                with parent_dir:
-                    inputrc = "inputrc-unicode" if use_unicode else "inputrc-no-unicode"
-                    try:
-                        read_init_file(str(parent_dir / "data" / inputrc))
-                    except:  # noqa
-                        pass
+                read_inputrc(use_unicode)
 
                 parse_and_bind("tab: complete")
                 self.completion_candidates = []

--- a/mathicsscript/termshell_prompt.py
+++ b/mathicsscript/termshell_prompt.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-#   Copyright (C) 2021 Rocky Bernstein <rb@dustyfeet.com>
+#   Copyright (C) 2021-2022 Rocky Bernstein <rb@dustyfeet.com>
 
 import locale
+import os
 import os.path as osp
 import re
 import sys
@@ -11,6 +12,7 @@ from mathicsscript.completion import MathicsCompleter
 from mathicsscript.termshell import (
     CONFIGDIR,
     HISTSIZE,
+    USER_INPUTRC,
     is_pygments_style,
     ShellEscapeException,
     TerminalShellCommon,
@@ -22,7 +24,7 @@ from mathics.core.attributes import attribute_string_to_number
 from mathics.core.expression import Expression, Symbol, from_python
 from mathics.core.rules import Rule
 
-from mathicsscript.bindkeys import bindings, read_inputrc
+from mathicsscript.bindkeys import bindings, read_inputrc, read_init_file
 
 from prompt_toolkit import PromptSession, HTML, print_formatted_text
 from prompt_toolkit.application.current import get_app
@@ -101,8 +103,8 @@ class TerminalShellPromptToolKit(TerminalShellCommon):
             try:
                 self.terminal_formatter = Terminal256Formatter(style=style)
             except ClassNotFound:
-                print(
-                    "Pygments style name '%s' not found; No pygments style set" % style
+                sys.stderr.write(
+                    f"Pygments style name '{style}' not found; No pygments style set\n"
                 )
 
         self.pygments_style = style
@@ -117,6 +119,13 @@ class TerminalShellPromptToolKit(TerminalShellCommon):
         )
 
         read_inputrc(use_unicode=use_unicode)
+        if osp.isfile(USER_INPUTRC):
+            if os.access(USER_INPUTRC, os.R_OK):
+                read_init_file(USER_INPUTRC)
+            else:
+                sys.stderr.write(
+                    f"Can't read user inputrc file {USER_INPUTRC}; skipping\n"
+                )
 
         self.definitions.add_message(
             "Settings`PygmentsStylesAvailable",


### PR DESCRIPTION
Fixes #58 (for prompt toolkit)

DRY mathicsscript/termshell_gnu.py

Customiztion for inputrc is in CONFIGDIR/inputrc
(e.g. ~/.config/mathicsscript/inputrc).

You can set the location this file via environment variable MATHICS_INPUTRC