### PR TITLE
Fix cairo for Windows

### DIFF
--- a/mathicsscript/__init__.py
+++ b/mathicsscript/__init__.py
@@ -4,11 +4,15 @@ mathicsscript is a command-line interface to Mathics.
 
 Copyright 2020-2021 The Mathics Team
 """
+from ctypes.util import find_library
+
+from mathicsscript.fixcairo import fix_cairo
 from mathicsscript.version import __version__
 
 
 def load_default_settings_files(definitions):
     import os.path as osp
+
     from mathics.core.definitions import autoload_files
 
     root_dir = osp.realpath(osp.dirname(__file__))
@@ -17,3 +21,6 @@ def load_default_settings_files(definitions):
 
 
 __all__ = ["__version__", "load_default_settings_files"]
+
+if not find_library("libcairo-2"):
+    fix_cairo()

--- a/mathicsscript/fixcairo.py
+++ b/mathicsscript/fixcairo.py
@@ -1,0 +1,51 @@
+"""
+Fix cairo for Windows, Python 3.8+
+"""
+
+import os
+import requests
+import sys
+
+cairo_libs_path = "./libs"
+
+def download_file(url, dest):
+    response = requests.get(url, timeout=5)
+    if response.status_code == 200:
+        with open(dest, 'wb') as file:
+            file.write(response.content)
+        print(f"Downloaded: {dest}")
+    else:
+        print(f"Failed to download: {url}")
+
+def download_cairo_libs():
+    branch_url = "https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/tree/master/"
+    directory_url = "gtk-nsis-pack/bin"
+    response = requests.get(branch_url + directory_url + "?recursive=1", timeout = 5)
+    if response.status_code == 200:
+        data = response.json()
+        for item in data['payload']['tree']['items']:
+            if '.dll' not in item['name']:
+                continue
+            file_url = branch_url + item['path']
+            file_path = os.path.join(cairo_libs_path, item['name'])
+            download_file(file_url, file_path)
+    else:
+        print("Failed to retrieve directory contents.")
+
+def set_dll_search_path():
+    # Python 3.8+ no longer searches for DLLs in PATH, so we have to add
+    # everything in PATH manually. Note that unlike PATH add_dll_directory
+    # has no defined order, so if there are two cairo DLLs in PATH we
+    # might get a random one.
+    if os.name != "nt" or not hasattr(os, "add_dll_directory"):
+        return
+    try:
+        os.add_dll_directory(cairo_libs_path)
+    except OSError:
+        pass
+
+
+if sys.version_info >= (3, 8) and os.name == 'nt' and not os.path.exists(cairo_libs_path):
+    os.makedirs(cairo_libs_path)
+    download_cairo_libs()
+    set_dll_search_path()

--- a/mathicsscript/fixcairo.py
+++ b/mathicsscript/fixcairo.py
@@ -73,7 +73,7 @@ def download_GTK_installer():
         file_path = os.path.join(mathicsscript_path, name)
         download_file(file_url, file_path, name)
         print("Done.")
-        return file_path
+        return file_path # path to GTK installer
     else:
         print("Failed to retrieve directory contents.")
 
@@ -101,16 +101,13 @@ def fix_cairo():
     else:
         choice = input(fix_cairo_long_intro).lower()
         if choice == "y" or choice == "":
-            GTK_installer = os.path.join(
-                mathicsscript_path, "gtk3-runtime-3.24.31-2022-01-04-ts-win64.exe"
-            )
-            # download_GTK_installer()
+            GTK_installer = download_GTK_installer()
             GTK_install_cmd = os.path.join(mathicsscript_path, "install_GTK.cmd")
             with open(os.path.join(mathicsscript_path, "install_GTK.cmd"), "w") as file:
                 file.write(f'"{GTK_installer}"')
             subprocess.run(
                 GTK_install_cmd
-            )  # Allow users to run installer as administrators
+            )  # Allow users to run installer as administrators. Tried to run it directly with subprocess.run(['runas', '/user:Administrator', ...]) and failed :(
             os.remove(GTK_install_cmd)
             set_dll_search_path()
             if os.path.exists(default_GTK_path):

--- a/mathicsscript/fixcairo.py
+++ b/mathicsscript/fixcairo.py
@@ -1,51 +1,123 @@
+# -*- coding: utf-8 -*-
 """
-Fix cairo for Windows, Python 3.8+
+Fix cairo for Windows
 """
 
 import os
+import platform
+import subprocess
+from ctypes.util import find_library
+from importlib.util import find_spec
+
 import requests
-import sys
+from tqdm import tqdm
 
-cairo_libs_path = "./libs"
+default_GTK_path = "C:\\Program Files\\GTK3-Runtime Win64\\bin"
 
-def download_file(url, dest):
-    response = requests.get(url, timeout=5)
+mathicsscript_path = find_spec("mathicsscript").submodule_search_locations[0]
+
+if platform.architecture()[0] == "64bit":
+    release_url = "https://api.github.com/repos/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases/latest"
+else:
+    release_url = "https://api.github.com/repos/miegir/GTK-for-Windows-Runtime-Environment-Installer-32/releases/latest"
+
+fix_cairo_long_intro = f"""
+We noticed that you are using mathicsscript on Windows. Due to a well known bug in the dependency
+package cairocffi for mathicsscript on Windows, mathicsscript is not working properly right now.
+We will now try to fix it, or you can visit https://github.com/Mathics3/mathicsscript/issues/76
+to fix it yourself.
+
+Specifically, cairocffi needs libcairo-2.dll and some other dll files to work properly on Windows.
+To get these libraries, we will download the latest GTK+ for Windows Runtime Environment Installer
+from {release_url}
+and install it for you. After installation, whenever you run mathicsscript, the GTK+ for Windows 
+dll libraries will be automatically loaded to make mathicsscript run properly.
+
+IMPORTANT: Remember to check the "Set up PATH environment variable to include GTK+" option!
+
+Please note that now the GTK+ for Windows dll libraries will only be loaded when mathicsscript is
+imported. If you want to load them when importing cairocffi, see 
+https://github.com/Mathics3/mathicsscript/issues/76.
+
+Do you want us to install GTK+ for Windows Runtime Environment for you? [Y/n] (default: Y)
+"""
+
+
+def download_file(url, dest, name=None):
+    response = requests.get(url, stream=True, timeout=5)
+    total_size = int(response.headers.get("content-length", 0))
     if response.status_code == 200:
-        with open(dest, 'wb') as file:
-            file.write(response.content)
-        print(f"Downloaded: {dest}")
+        with open(dest, "wb") as file:
+            with tqdm(
+                total=total_size,
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+                desc=f"Downloading {name}",
+            ) as pbar:
+                for chunk in response.iter_content(chunk_size=1024):
+                    if chunk:
+                        file.write(chunk)
+                        file.flush()
+                        pbar.update(len(chunk))
+                        pbar.refresh()
     else:
         print(f"Failed to download: {url}")
 
-def download_cairo_libs():
-    branch_url = "https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/tree/master/"
-    directory_url = "gtk-nsis-pack/bin"
-    response = requests.get(branch_url + directory_url + "?recursive=1", timeout = 5)
+
+def download_GTK_installer():
+    response = requests.get(release_url, timeout=5)
     if response.status_code == 200:
-        data = response.json()
-        for item in data['payload']['tree']['items']:
-            if '.dll' not in item['name']:
-                continue
-            file_url = branch_url + item['path']
-            file_path = os.path.join(cairo_libs_path, item['name'])
-            download_file(file_url, file_path)
+        name = response.json()["assets"][0]["name"]
+        file_url = response.json()["assets"][0]["browser_download_url"]
+        file_path = os.path.join(mathicsscript_path, name)
+        download_file(file_url, file_path, name)
+        print("Done.")
+        return file_path
     else:
         print("Failed to retrieve directory contents.")
 
+
 def set_dll_search_path():
-    # Python 3.8+ no longer searches for DLLs in PATH, so we have to add
-    # everything in PATH manually. Note that unlike PATH add_dll_directory
-    # has no defined order, so if there are two cairo DLLs in PATH we
-    # might get a random one.
-    if os.name != "nt" or not hasattr(os, "add_dll_directory"):
+    """
+    Python 3.8+ no longer searches for DLLs in PATH, so we have to add
+    everything in PATH manually. Note that unlike PATH add_dll_directory
+    has no defined order, so if there are two cairo DLLs in PATH we
+    might get a random one.
+    """
+    if not hasattr(os, "add_dll_directory"):
         return
-    try:
-        os.add_dll_directory(cairo_libs_path)
-    except OSError:
-        pass
+    for path in os.environ.get("PATH", "").split(os.pathsep):
+        try:
+            os.add_dll_directory(path)
+        except OSError:
+            pass
 
 
-if sys.version_info >= (3, 8) and os.name == 'nt' and not os.path.exists(cairo_libs_path):
-    os.makedirs(cairo_libs_path)
-    download_cairo_libs()
+def fix_cairo():
     set_dll_search_path()
+    if find_library("libcairo-2"):
+        return
+    else:
+        choice = input(fix_cairo_long_intro).lower()
+        if choice == "y" or choice == "":
+            GTK_installer = os.path.join(
+                mathicsscript_path, "gtk3-runtime-3.24.31-2022-01-04-ts-win64.exe"
+            )
+            # download_GTK_installer()
+            GTK_install_cmd = os.path.join(mathicsscript_path, "install_GTK.cmd")
+            with open(os.path.join(mathicsscript_path, "install_GTK.cmd"), "w") as file:
+                file.write(f'"{GTK_installer}"')
+            subprocess.run(
+                GTK_install_cmd
+            )  # Allow users to run installer as administrators
+            os.remove(GTK_install_cmd)
+            set_dll_search_path()
+            if os.path.exists(default_GTK_path):
+                os.environ["PATH"] += os.pathsep + default_GTK_path
+            if find_library("libcairo-2"):
+                print("Successfully fixed cairocffi for mathicsscript.")
+            else:
+                print(
+                    "Please restart the current terminal to make the changes take effect."
+                )

--- a/mathicsscript/fixcairo.py
+++ b/mathicsscript/fixcairo.py
@@ -10,7 +10,8 @@ from ctypes.util import find_library
 from importlib.util import find_spec
 
 import requests
-from tqdm import tqdm
+if os.name == "nt":
+    from tqdm import tqdm
 
 mathicsscript_path = find_spec("mathicsscript").submodule_search_locations[0]
 

--- a/mathicsscript/format.py
+++ b/mathicsscript/format.py
@@ -8,6 +8,7 @@ import networkx as nx
 import os
 import random
 import requests
+import sys
 from tempfile import NamedTemporaryFile
 
 from mathics.core.atoms import String

--- a/mathicsscript/format.py
+++ b/mathicsscript/format.py
@@ -56,10 +56,23 @@ def download_cairo_libs():
     else:
         print("Failed to retrieve directory contents.")
 
+def set_dll_search_path():
+    # Python 3.8+ no longer searches for DLLs in PATH, so we have to add
+    # everything in PATH manually. Note that unlike PATH add_dll_directory
+    # has no defined order, so if there are two cairo DLLs in PATH we
+    # might get a random one.
+    if os.name != "nt" or not hasattr(os, "add_dll_directory"):
+        return
+    try:
+        os.add_dll_directory(cairo_libs_path)
+    except OSError:
+        pass
+
 
 if sys.version_info >= (3, 8) and os.name == 'nt' and not os.path.exists(cairo_libs_path):
     os.makedirs(cairo_libs_path)
     download_cairo_libs()
+    set_dll_search_path()
 
 try:
     from matplotlib import __version__ as matplotlib_version

--- a/mathicsscript/format.py
+++ b/mathicsscript/format.py
@@ -5,10 +5,7 @@ Format Mathics objects
 from typing import Callable
 import math
 import networkx as nx
-import os
 import random
-import requests
-import sys
 from tempfile import NamedTemporaryFile
 
 from mathics.core.atoms import String
@@ -29,50 +26,6 @@ from mathics.core.systemsymbols import (
 from mathics.session import get_settings_value
 
 PyMathicsGraph = Symbol("Pymathics`Graph")
-
-cairo_libs_path = "./libs"
-
-def download_file(url, dest):
-    response = requests.get(url, timeout=5)
-    if response.status_code == 200:
-        with open(dest, 'wb') as file:
-            file.write(response.content)
-        print(f"Downloaded: {dest}")
-    else:
-        print(f"Failed to download: {url}")
-
-def download_cairo_libs():
-    branch_url = "https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/tree/master/"
-    directory_url = "gtk-nsis-pack/bin"
-    response = requests.get(branch_url + directory_url + "?recursive=1", timeout = 5)
-    if response.status_code == 200:
-        data = response.json()
-        for item in data['payload']['tree']['items']:
-            if '.dll' not in item['name']:
-                continue
-            file_url = branch_url + item['path']
-            file_path = os.path.join(cairo_libs_path, item['name'])
-            download_file(file_url, file_path)
-    else:
-        print("Failed to retrieve directory contents.")
-
-def set_dll_search_path():
-    # Python 3.8+ no longer searches for DLLs in PATH, so we have to add
-    # everything in PATH manually. Note that unlike PATH add_dll_directory
-    # has no defined order, so if there are two cairo DLLs in PATH we
-    # might get a random one.
-    if os.name != "nt" or not hasattr(os, "add_dll_directory"):
-        return
-    try:
-        os.add_dll_directory(cairo_libs_path)
-    except OSError:
-        pass
-
-
-if sys.version_info >= (3, 8) and os.name == 'nt' and not os.path.exists(cairo_libs_path):
-    os.makedirs(cairo_libs_path)
-    download_cairo_libs()
-    set_dll_search_path()
 
 try:
     from matplotlib import __version__ as matplotlib_version

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         # "mathics_pygments @ https://github.com/Mathics3/mathics-pygments/archive/master.zip#egg=mathics_pygments",
         "mathics_pygments>=1.0.2",
         "term-background >= 1.0.1",
-        'tqdm',
+        "tqdm; platform_system=='Windows'",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         # "mathics_pygments @ https://github.com/Mathics3/mathics-pygments/archive/master.zip#egg=mathics_pygments",
         "mathics_pygments>=1.0.2",
         "term-background >= 1.0.1",
+        'tqdm',
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Add fixcairo.py to install GTK+ for Windows Runtime Environment for users if needed. Automatically load GTK+ dlls when mathicsscript starts.

- Tried to download GTK+ dlls only (instead of installing full GTK+) and failed.
- Tried to run GTK+ installer as administrators directly in fixcairo.py (instead of using GTK_install_cmd) and failed.
- Tried to get instant update of system PATH (instead of manually searching and adding GTK+ dlls to os.environ["PATH"]) and failed

### TODO:
Update setup.py to automatically run fix_cairo() for Windows after installation.