### PR TITLE
Work around a bug giving Set:setraw error

### DIFF
--- a/mathicsscript/autoload/settings.m
+++ b/mathicsscript/autoload/settings.m
@@ -13,6 +13,12 @@ Note this is for input entered, not the output of the evaluated result.
 "
 
 Settings`$ShowFullFormInput = False
+
+(* This is a workarund for a bug in mathicsscript of mathics-core.
+ Remove this and we get error:
+ Set::setraw: Cannot assign to raw object colorful. *)
+Settings`$PygmentsStyle = False
+
 Settings`$PygmentsStyle::usage = "This variable sets the Pygments style used to colorize output. The value should be a string.
 
 The default value changes background depending on whether the terminal has a light or dark background. You can also set the color style used on the command with the ``--style`` option, or look at the variable ```Settings`PygmentsStylesAvailable```. Or it can be set in the settings.m file."


### PR DESCRIPTION
@mmatera in mathisccript we are now seeing this bug that happened since the last release.

Without this bogus assignment to False as opposed to a String which happens in main. I see the message
```
Set::setraw: Cannot assign to raw object colorful.
```

"colorful" is the value of the String that is trying to be set in line 364 of `__main__.py`.  Line 751 or so is the place inside mathics.core.assignment where the error message is produced.

Have any idea what's up here?  


