### PR TITLE
Definitions.get_ownvalue now returns a BaseElement.

### DIFF
--- a/mathicsscript/__main__.py
+++ b/mathicsscript/__main__.py
@@ -162,11 +162,11 @@ def interactive_eval_loop(
 
             full_form = definitions.get_ownvalue(
                 "Settings`$ShowFullFormInput"
-            ).replace.to_python()
+            ).to_python()
             style = definitions.get_ownvalue("Settings`$PygmentsStyle")
             fmt = identity
             if style:
-                style = style.replace.get_string_value()
+                style = style.get_string_value()
                 if shell.terminal_formatter:
                     fmt = fmt_fun
 

--- a/mathicsscript/termshell.py
+++ b/mathicsscript/termshell.py
@@ -119,17 +119,15 @@ class TerminalShellCommon(MathicsLineFeeder):
 
         self.pygments_style = style
         self.definitions = definitions
-        set_settings_value(
-            self.definitions, "Settings`$PygmentsShowTokens", from_python(False)
+        self.definitions.set_ownvalue(
+            "Settings`$PygmentsShowTokens", from_python(False)
         )
-        set_settings_value(
-            self.definitions, "Settings`$UseUnicode", from_python(use_unicode)
+        self.definitions.set_ownvalue("Settings`$PygmentsStyle", from_python(style))
+        self.definitions.set_ownvalue("Settings`$UseUnicode", from_python(use_unicode))
+        self.definitions.set_ownvalue(
+            "Settings`PygmentsStylesAvailable", from_python(ALL_PYGMENTS_STYLES)
         )
-        set_settings_value(
-            self.definitions,
-            "Settings`PygmentsStylesAvailable",
-            from_python(ALL_PYGMENTS_STYLES),
-        )
+
         self.definitions.add_message(
             "Settings`PygmentsStylesAvailable",
             Rule(

--- a/mathicsscript/termshell_prompt.py
+++ b/mathicsscript/termshell_prompt.py
@@ -167,7 +167,7 @@ class TerminalShellPromptToolKit(TerminalShellCommon):
         if self.definitions.get_ownvalue("Settings`$GroupAutocomplete"):
             app.group_autocomplete = self.definitions.get_ownvalue(
                 "Settings`$GroupAutocomplete"
-            ).replace.to_python()
+            ).to_python()
 
         edit_mode = "Vi" if app.editing_mode == EditingMode.VI else "Emacs"
         return HTML(
@@ -224,10 +224,10 @@ class TerminalShellPromptToolKit(TerminalShellCommon):
             elif self.terminal_formatter:  # pygmentize
                 show_pygments_tokens = self.definitions.get_ownvalue(
                     "Settings`$PygmentsShowTokens"
-                ).replace.to_python()
+                ).to_python()
                 pygments_style = self.definitions.get_ownvalue(
                     "Settings`$PygmentsStyle"
-                ).replace.get_string_value()
+                ).get_string_value()
                 if pygments_style != self.pygments_style:
                     if not self.change_pygments_style(pygments_style):
                         self.definitions.set_ownvalue(


### PR DESCRIPTION
This PR together with https://github.com/Mathics3/mathics-core/pull/1278#issue-2778235838 should fix #87.

With the change in mathics-core, now `Definitions.get_ownvalue` returns a `BaseElement` instead of a `Rule`.