### PR TITLE
Bug fixes

### DIFF
--- a/mathicsscript/bindkeys.py
+++ b/mathicsscript/bindkeys.py
@@ -64,7 +64,10 @@ def curly_right(event):
 def paren_left(event):
     b = event.cli.current_buffer
     b.insert_text("(")
-    b.insert_text(")", move_cursor=False)
+    if len(b.text) > 1 and b.text[-2] == "\\":
+        b.insert_text("\\)", move_cursor=False)
+    else:
+        b.insert_text(")", move_cursor=False)
 
 
 @bindings.add(")", filter=autocomplete_on)

--- a/mathicsscript/termshell.py
+++ b/mathicsscript/termshell.py
@@ -278,7 +278,7 @@ class TerminalShellCommon(MathicsLineFeeder):
     def feed(self):
         prompt_str = self.get_in_prompt() if self.prompt else ""
         result = self.read_line(prompt_str) + "\n"
-        if mathics_scanner.location.TRACK_LOCATIONS:
+        if mathics_scanner.location.TRACK_LOCATIONS and self.source_text is not None:
             self.container.append(self.source_text)
         if result == "\n":
             return ""  # end of input

--- a/mathicsscript/termshell_prompt.py
+++ b/mathicsscript/termshell_prompt.py
@@ -16,6 +16,7 @@ from mathics.core.rules import Rule
 from mathics.core.symbols import SymbolNull
 from mathics.core.systemsymbols import SymbolMessageName
 from mathics_pygments.lexer import MathematicaLexer, MToken
+from mathics_scanner.location import ContainerKind
 from prompt_toolkit import HTML, PromptSession, print_formatted_text
 from prompt_toolkit.application.current import get_app
 from prompt_toolkit.enums import EditingMode
@@ -67,7 +68,7 @@ class TerminalShellPromptToolKit(TerminalShellCommon):
         prompt: bool,
         edit_mode: Optional[str],
     ):
-        super(TerminalShellCommon, self).__init__("<stdin>")
+        super(TerminalShellCommon, self).__init__([], ContainerKind.STREAM)
         self.input_encoding = locale.getpreferredencoding()
         self.lineno = 0
         self.terminal_formatter = None


### PR DESCRIPTION
* Adjust MathicsLineFeeder initialization for updated API. 
* Match `\(` with '\)' in prompt-toolkit mode.